### PR TITLE
PHP 8.1 compatibility & deprecation warnings

### DIFF
--- a/lib/Shippo/Object.php
+++ b/lib/Shippo/Object.php
@@ -96,21 +96,21 @@ class Shippo_Object implements ArrayAccess
     }
     
     // ArrayAccess methods
-    public function offsetSet($k, $v)
+    public function offsetSet($k, $v): void
     {
         $this->$k = $v;
     }
     
-    public function offsetExists($k)
+    public function offsetExists($k): bool
     {
         return array_key_exists($k, $this->_values);
     }
     
-    public function offsetUnset($k)
+    public function offsetUnset($k): void
     {
         unset($this->$k);
     }
-    public function offsetGet($k)
+    public function offsetGet($k): mixed
     {
         return array_key_exists($k, $this->_values) ? $this->_values[$k] : null;
     }


### PR DESCRIPTION
Full explanation: https://stackoverflow.com/a/71133750
`Shippo_Object` implements `ArrayAccess`: https://www.php.net/manual/en/class.arrayaccess.php

Warnings getting in PHP log:

PHP Deprecated:  Return type of Shippo_Object::offsetUnset($k) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../vendor/shippo/shippo-php/lib/Shippo/Object.php on line 109

PHP Deprecated:  Return type of Shippo_Object::offsetSet($k, $v) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../vendor/shippo/shippo-php/lib/Shippo/Object.php on line 99